### PR TITLE
Fix/formatting

### DIFF
--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -81,9 +81,52 @@ class DtsFormatter {
         // Normalize line endings first
         data = data.replace(/\r\n/g, '\n');
 
-        // Normalize labels and node references
+        // Normalize labels (but not inside quoted strings)
+        // Split by strings, process parts outside strings, then rejoin
+        data = data.split('\n').map(line => {
+            // Split line into string and non-string parts
+            const parts: string[] = [];
+            const stringParts: boolean[] = [];
+            let lastIndex = 0;
+
+            // Find all quoted strings
+            const stringRegex = /"(?:[^"\\]|\\.)*"/g;
+            let match;
+
+            while ((match = stringRegex.exec(line)) !== null) {
+                // Add part before string
+                if (match.index > lastIndex) {
+                    parts.push(line.substring(lastIndex, match.index));
+                    stringParts.push(false);
+                }
+                // Add the string itself
+                parts.push(match[0]);
+                stringParts.push(true);
+                lastIndex = match.index + match[0].length;
+            }
+
+            // Add remaining part after last string
+            if (lastIndex < line.length) {
+                parts.push(line.substring(lastIndex));
+                stringParts.push(false);
+            }
+
+            // Process non-string parts to normalize colons in labels
+            const processed = parts.map((part, index) => {
+                if (stringParts[index]) {
+                    // Inside string - don't modify
+                    return part;
+                }
+                // Outside string - normalize label colons
+                // Match word (label) followed by colon and optional whitespace
+                return part.replace(/([\w,-]+):\s*/g, '$1: ');
+            });
+
+            return processed.join('');
+        }).join('\n');
+
+        // Normalize node references and addresses
         data = data
-            .replace(/([\w,-]+)\s*:[\t ]*/g, '$1: ')
             .replace(/(&[\w,-]+)\s*{[\t ]*/g, '$1 {')
             .replace(/([\w,-]+)\s*@\s*0*([\da-fA-F]+)\s*{[\t ]*/g, '$1@$2 {')
             .replace(/([\w,-]+)\s+{/g, '$1 {');

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -225,23 +225,76 @@ class DtsFormatter {
 
     /**
      * Parse comma-separated values while preserving comments
+     * Handles both comma-separated (< val1 >, < val2 >) and whitespace-separated (< val1 val2 >)
      * @param val The value string to parse
      * @returns Array of parsed values with comments preserved
      */
     private parseCommaSeparatedValues(val: string): string[] {
-        const regex = /((?:".*?"|<.*?>|\[.*?\]|[^,])+?,?)([ \t]*(?:\/\/.*|\/\*.*?\*\/)?)?/gm;
+        const trimmed = val.trim();
+
+        // Check if this is whitespace-separated (no commas outside of parentheses/brackets)
+        // Pattern: < val1 val2 val3 > or values with function calls like PDO_FIXED(...)
+        const hasCommas = this.hasSignificantCommas(trimmed);
+        if (!hasCommas) {
+            return trimmed.trim() ? [trimmed] : [];
+        }
+
+        // Comma-separated values - use the original logic
+        const regex = /((?:".*?"|<[^>]*>|\[[^\]]*\]|[^,])+)(,?)([ \t]*(?:\/\/.*|\/\*.*?\*\/)?)?/g;
         const values: string[] = [];
         let entry: RegExpExecArray | null;
 
-        while ((entry = regex.exec(val)) !== null) {
-            const valuePart = entry[1].trimEnd();
-            const commentPart = entry[2]?.trimEnd() ?? '';
+        while ((entry = regex.exec(trimmed)) !== null) {
+            const valuePart = entry[1].trim();
+            const comma = entry[2];
+            const commentPart = entry[3]?.trim() ?? '';
+
             if (valuePart || commentPart) {
-                values.push(valuePart + (commentPart ? ' ' + commentPart : ''));
+                const fullValue = valuePart + comma + (commentPart ? ' ' + commentPart : '');
+                values.push(fullValue);
             }
         }
 
         return values;
+    }
+
+    /**
+     * Check if a value string has commas that act as value separators (i.e. are not
+     * nested inside parentheses or angle-bracket groups).
+     *
+     * Significant (separating) commas:
+     *   `<&clk1>, <&clk2>`          — comma between two `<...>` entries
+     *   `"a", "b"`                  — comma between two string literals
+     *
+     * Non-significant (nested) commas:
+     *   `<PDO_FIXED(5000, 3000, PDO_FIXED_USB_COMM)>` — commas inside `(...)` at depth > 1
+     *   `< 0 1 2 3 >`               — no commas at all; whitespace-separated array
+     *
+     * @param val The value string to check (typically the right-hand side of a `=`)
+     * @returns True if at least one comma separates top-level values
+     */
+    private hasSignificantCommas(val: string): boolean {
+        let depth = 0;
+        let inString = false;
+
+        for (let i = 0; i < val.length; i++) {
+            const char = val[i];
+
+            if (char === '"' && (i === 0 || val[i - 1] !== '\\')) {
+                inString = !inString;
+            } else if (!inString) {
+                if (char === '(' || char === '[' || char === '<') {
+                    depth++;
+                } else if (char === ')' || char === ']' || char === '>') {
+                    depth--;
+                } else if (char === ',' && depth <= 1) {
+                    // Found a comma at top level or just inside the outer brackets
+                    return true;
+                }
+            }
+        }
+
+        return false;
     }
 
     /**
@@ -423,13 +476,106 @@ class DtsFormatter {
      */
     private calculateValueAlignment(indentation: string, prop: string): string {
         const start = `${indentation}${prop} = `;
-        const eqPos = this.replaceTabsWithSpaces(start).length;
-        const tabCount = Math.floor(eqPos / this.tabSize);
-        const spaceCount = eqPos % this.tabSize;
+        return this.calculateAlignmentForColumn(this.replaceTabsWithSpaces(start).length);
+    }
 
+    /**
+     * Align text to a specific column based on current indentation and tab settings
+     * @param col Target column for alignment
+     * @returns String of tabs and/or spaces to reach the target column
+     */
+    private calculateAlignmentForColumn(col: number): string {
         return this.useTabs
-            ? '\t'.repeat(tabCount) + ' '.repeat(spaceCount)
-            : ' '.repeat(eqPos);
+            ? '\t'.repeat(Math.floor(col / this.tabSize)) + ' '.repeat(col % this.tabSize)
+            : ' '.repeat(col);
+    }
+
+    /**
+     * Format whitespace-separated content lines with column alignment
+     * @param lines Content lines to format
+     * @param baseIndent Base indentation for each line
+     * @returns Formatted lines with column alignment
+     */
+    private formatWhitespaceSeparatedLines(lines: string[], baseIndent: string): string[] {
+        if (lines.length === 0) {
+            return [];
+        }
+
+        type CommentLine = { isComment: true; raw: string };
+        type EntryLine = { isComment: false; key: string; value: string; suffix: string };
+        type ParsedLine = CommentLine | EntryLine;
+
+        // Parse each line: comment-only lines are preserved as-is; entry lines are split
+        // into key, value, and optional trailing suffix (e.g. inline /* comment */).
+        const parsedLines: ParsedLine[] = lines.map(line => {
+            const trimmed = line.trim();
+            // Lines that are purely comment content (block or line comments)
+            if (/^(\/\*|\*|\/\/)/.test(trimmed)) {
+                return { isComment: true, raw: trimmed } as CommentLine;
+            }
+            // Split into key / value / optional trailing suffix
+            const firstSpace = trimmed.search(/\s+/);
+            if (firstSpace < 0) {
+                return { isComment: true, raw: trimmed } as CommentLine;
+            }
+            const key = trimmed.slice(0, firstSpace);
+            const afterKey = trimmed.slice(firstSpace).trimStart();
+            const secondSpace = afterKey.search(/\s/);
+            if (secondSpace < 0) {
+                return { isComment: false, key, value: afterKey, suffix: '' } as EntryLine;
+            }
+            return {
+                isComment: false,
+                key,
+                value: afterKey.slice(0, secondSpace),
+                suffix: afterKey.slice(secondSpace),   // leading whitespace preserved
+            } as EntryLine;
+        });
+
+        const entryLines = parsedLines.filter((p): p is EntryLine => !p.isComment);
+
+        // All non-comment lines must have a value for column alignment to make sense.
+        // Also skip if any key looks like a function call or value contains a comma —
+        // that indicates content like PDO_FIXED(5000, 3000, ...) rather than PIN HEX pairs.
+        const shouldAlign = entryLines.length > 0 && entryLines.every(
+            p => p.value !== '' && !p.key.includes('(') && !p.value.includes(',')
+        );
+        if (!shouldAlign) {
+            return lines.map(line => baseIndent + line.trim());
+        }
+
+        // Skip alignment for purely numeric arrays (e.g. brightness-levels)
+        const allNumeric = entryLines.every(p =>
+            (/^[0-9]+$/.test(p.key) || p.key.length <= 3) &&
+            (/^[0-9]+$/.test(p.value) || p.value.length <= 3)
+        );
+        if (allNumeric) {
+            return lines.map(line => baseIndent + line.trim());
+        }
+
+        const baseIndentWidth = this.replaceTabsWithSpaces(baseIndent).length;
+        const maxFirstColWidth = Math.max(...entryLines.map(p =>
+            this.replaceTabsWithSpaces(p.key).length
+        ));
+        // Tabs: round up to the next tab stop after the longest key.
+        // Spaces: exactly 1 space after the longest key, no rounding.
+        const targetColumn = this.useTabs
+            ? Math.ceil((baseIndentWidth + maxFirstColWidth + 1) / this.tabSize) * this.tabSize
+            : baseIndentWidth + maxFirstColWidth + 1;
+
+        return parsedLines.map(p => {
+            if (p.isComment) {
+                return baseIndent + p.raw;
+            }
+            const firstPartWidth = this.replaceTabsWithSpaces(p.key).length;
+            let spacing: string;
+            if (this.useTabs) {
+                spacing = this.calculateTabSpaceAlignment(baseIndentWidth + firstPartWidth, targetColumn);
+            } else {
+                spacing = ' '.repeat(Math.max(1, targetColumn - baseIndentWidth - firstPartWidth));
+            }
+            return baseIndent + p.key + spacing + p.value + p.suffix;
+        });
     }
 
     /**
@@ -485,6 +631,39 @@ class DtsFormatter {
             return start + val + ';';
         }
 
+        // If there's only one value (whitespace-separated array), format with proper alignment
+        if (values.length === 1 && val.includes('\n')) {
+            const lines = val.split('\n').map(l => l.trim()).filter(l => l.length > 0);
+
+            if (lines.length === 0) {
+                return start + ';';
+            }
+            if (lines.length === 1) {
+                return start + lines[0] + (lines[0].endsWith(';') ? '' : ';');
+            }
+
+            // Extract content entries from all lines, stripping '<' prefix and '>;'/'>' suffix
+            const contentLines: string[] = [];
+            for (let i = 0; i < lines.length; i++) {
+                let line = i === 0 ? lines[i].replace(/^<\s*/, '') : lines[i];
+                if (i === lines.length - 1) {
+                    line = line.replace(/>;?$/, '').trim();
+                }
+                if (line) {
+                    contentLines.push(line);
+                }
+            }
+
+            if (contentLines.length === 0) {
+                return start + '<>;';
+            }
+
+            const bracketAlign = this.calculateAlignmentForColumn(this.replaceTabsWithSpaces(start + '<').length);
+            const allFormatted = this.formatWhitespaceSeparatedLines(contentLines, bracketAlign);
+            const firstEntry = allFormatted[0].slice(bracketAlign.length);
+            return [start + '<' + firstEntry, ...allFormatted.slice(1), indentation + '>;'].join('\n');
+        }
+
         // Check if we can format as single line (ignoring comments for length check)
         const singleLineResult = this.tryFormatAsSingleLine(start, val, values);
         if (singleLineResult) {
@@ -520,7 +699,10 @@ class DtsFormatter {
                     }
 
                     const fullLine = `${indentation}${prop} = ${cleanVal}${extractedComment ? `; ${extractedComment}` : ';'}`;
-                    if (this.replaceTabsWithSpaces(fullLine).length <= this.maxLineLength) {
+                    // In spaces mode, skip the early return if the value still contains tabs
+                    // so it falls through to formatMultiLineProperty which converts them properly.
+                    if (this.replaceTabsWithSpaces(fullLine).length <= this.maxLineLength &&
+                        (this.useTabs || !cleanVal.includes('\t'))) {
                         return fullLine;
                     }
                 }

--- a/src/test/diagnostics.test.ts
+++ b/src/test/diagnostics.test.ts
@@ -9,9 +9,7 @@ suiteSetup(async () => {
     }
 });
 
-/**
- * Helper function to get diagnostics for a document
- */
+// Helper function to get diagnostics for a document
 async function getDiagnostics(content: string): Promise<vscode.Diagnostic[]> {
     const doc = await vscode.workspace.openTextDocument({
         language: 'dts',

--- a/src/test/formatter.test.ts
+++ b/src/test/formatter.test.ts
@@ -407,4 +407,11 @@ pinctrl-0 = <&pinctrl_uart>;
         assert.ok(result.includes('uart_pins: uart-pins {'));
         assert.ok(result.includes('function = "uart"'));
     });
+
+    test('Should preserve strings with colons', async () => {
+        const input = '/ {\n\tlabel = "yellow:status";\n};';
+        const result = await formatDocument(input);
+        assert.ok(result.includes('"yellow:status"'), 'String content should not be modified');
+        assert.ok(!result.includes('"yellow: status"'), 'Colon in string should not have space added');
+    });
 });

--- a/src/test/formatter.test.ts
+++ b/src/test/formatter.test.ts
@@ -1,9 +1,7 @@
 import * as assert from 'assert';
 import * as vscode from 'vscode';
 
-/**
- * Helper function to format a DTS document
- */
+// Helper function to format a DTS document
 async function formatDocument(content: string, options?: vscode.FormattingOptions): Promise<string> {
     const doc = await vscode.workspace.openTextDocument({
         language: 'dts',
@@ -40,6 +38,27 @@ suiteSetup(async () => {
         await extension.activate();
     }
 });
+
+// Expand tabs to spaces so that .indexOf() returns a visual column number.
+// Assumes a single line (no newlines); the internal column counter is never reset.
+// Usage: expandTabs(line).indexOf('0x') gives the screen column where '0x' appears,
+// making it possible to assert that two lines align their hex values at the same
+// visual position even when they use different numbers of tabs for padding.
+function expandTabs(chars: string, tabSize = 8): string {
+    let result = '';
+    let col = 0;
+    for (const ch of chars) {
+        if (ch === '\t') {
+            const pad = tabSize - (col % tabSize);
+            result += ' '.repeat(pad);
+            col += pad;
+        } else {
+            result += ch;
+            col++;
+        }
+    }
+    return result;
+}
 
 suite('DTS Formatter - Basic Indentation', () => {
     test('Should indent root properties', async () => {
@@ -125,7 +144,7 @@ suite('DTS Formatter - Node Formatting', () => {
 });
 
 suite('DTS Formatter - Multi-line Properties', () => {
-    test('Should handle comma-separated values', async () => {
+    test('Should preserve all phandle references in a comma-separated cell list', async () => {
         const input = '/ {\nclocks = <&clk1>,<&clk2>,<&clk3>;\n};';
         const result = await formatDocument(input);
         // Should format with proper alignment
@@ -142,7 +161,7 @@ suite('DTS Formatter - Multi-line Properties', () => {
         assert.ok(result.includes('&pinctrl_set1'));
     });
 
-    test('Should handle key-value pairs', async () => {
+    test('Should preserve multi-token entries in a comma-separated cell array', async () => {
         const input = '/ {\nclocks = <IMX8MP_CLK_IPP_DO_CLKO1 10000>, <IMX8MP_SYS_PLL1_80M 20000>;\n};';
         const result = await formatDocument(input);
         assert.ok(result.includes('IMX8MP_CLK_IPP_DO_CLKO1'));
@@ -224,7 +243,7 @@ suite('DTS Formatter - Indentation Options', () => {
         const lines = result.split('\n');
         const propLine = lines.find(line => line.includes('prop'));
         assert.ok(propLine);
-        // Nested property should have 8 spaces (2 levels * 4 spaces)
+        // Nested property with spaces
         assert.ok(/^\s{8}prop/.test(propLine));
     });
 });
@@ -238,7 +257,7 @@ suite('DTS Formatter - Complex Structures', () => {
         assert.ok(result.includes('compatible = "vendor,board"'));
     });
 
-    test('Should handle mixed nodes and references', async () => {
+    test('Should format both inline node definitions and ampersand reference overrides', async () => {
         const input = `/ {
 uart0: uart@12345678 {
 compatible = "vendor,uart";
@@ -254,7 +273,7 @@ status = "okay";
         assert.ok(result.includes('status = "okay"'));
     });
 
-    test('Should handle deeply nested structure', async () => {
+    test('Should apply one additional tab per nesting level for deeply nested nodes', async () => {
         const input = '/ {\nbus {\ndevice {\nsubdevice {\nproperty = <1>;\n};\n};\n};\n};';
         const result = await formatDocument(input);
         const lines = result.split('\n');
@@ -304,14 +323,14 @@ suite('DTS Formatter - Edge Cases', () => {
         assert.strictEqual(result, '');
     });
 
-    test('Should handle document with only whitespace', async () => {
+    test('Should not throw and return a string for whitespace-only input', async () => {
         const input = '   \n\t\n  ';
         const result = await formatDocument(input);
         // Should handle gracefully
         assert.ok(typeof result === 'string');
     });
 
-    test('Should handle root node only', async () => {
+    test('Should expand single-line root node body to multi-line block format', async () => {
         const input = '/ { };';
         const expected = '/ {\n};';
         const result = await formatDocument(input);
@@ -325,7 +344,7 @@ suite('DTS Formatter - Edge Cases', () => {
         assert.strictEqual(result, expected);
     });
 
-    test('Should handle property with empty value', async () => {
+    test('Should preserve valueless boolean property without modification', async () => {
         const input = '/ {\nempty-prop;\n};';
         const result = await formatDocument(input);
         assert.ok(result.includes('empty-prop'));
@@ -345,13 +364,13 @@ suite('DTS Formatter - Special DTS Syntax', () => {
         assert.ok(result.includes('#include "board.dtsi"'));
     });
 
-    test('Should handle phandle properties', async () => {
+    test('Should preserve phandle cell value in angle bracket notation', async () => {
         const input = '/ {\nnode {\nphandle = <0x1>;\n};\n};';
         const result = await formatDocument(input);
         assert.ok(result.includes('phandle = <0x1>'));
     });
 
-    test('Should handle multiple references', async () => {
+    test('Should preserve all phandle references in a multi-value cell array', async () => {
         const input = '/ {\nnode {\nclocks = <&clk1>, <&clk2>, <&clk3>;\n};\n};';
         const result = await formatDocument(input);
         assert.ok(result.includes('&clk1'));
@@ -413,5 +432,244 @@ pinctrl-0 = <&pinctrl_uart>;
         const result = await formatDocument(input);
         assert.ok(result.includes('"yellow:status"'), 'String content should not be modified');
         assert.ok(!result.includes('"yellow: status"'), 'Colon in string should not have space added');
+    });
+
+    test('Should not split whitespace-separated arrays into new lines', async () => {
+        const input = `/ {
+\tbrightness-levels = < 0  1  2  3  4  5  6  7  8  9
+\t\t\t     10 11 12 13 14 15 >;
+};`;
+        const result = await formatDocument(input);
+        // Should preserve multi-line structure
+        assert.ok(result.includes('brightness-levels'), 'Property name should be present');
+        const lines = result.split('\n');
+        const brightLine = lines.findIndex(l => l.includes('brightness-levels'));
+        assert.ok(brightLine >= 0, 'brightness-levels property should exist');
+        // The values should not be split into individual digits
+        assert.ok(!result.match(/brightness-levels.*\n.*0\n.*1\n.*2/), 'Should not split digits');
+    });
+
+    test('Should not split PDO macro function names or parenthesized arguments across lines', async () => {
+        const input = `/ {
+\tsink-pdos = <PDO_FIXED(5000, 3000, PDO_FIXED_USB_COMM)
+\t\t     PDO_VAR(5000, 20000, 3000)>;
+};`;
+        const result = await formatDocument(input);
+        // Should keep PDO_FIXED as a single token, not split into characters
+        assert.ok(result.includes('PDO_FIXED'), 'PDO_FIXED should remain intact');
+        assert.ok(result.includes('PDO_VAR'), 'PDO_VAR should remain intact');
+        // Make sure it's not split character by character
+        assert.ok(!result.match(/P\s+D\s+O\s+_\s+F/), 'Should not split macro name into characters');
+    });
+
+    test('Should not split long iomuxc pin control macro names across lines', async () => {
+        const input = `&iomuxc {
+\tpinctrl_hog: hoggrp {
+\t\tfsl,pins = <
+\t\t\tMX8MP_IOMUXC_HDMI_DDC_SCL__HDMIMIX_HDMI_SCL\t0x400001c2
+\t\t\tMX8MP_IOMUXC_HDMI_DDC_SDA__HDMIMIX_HDMI_SDA\t0x400001c2
+\t\t>;
+\t};
+};`;
+        const result = await formatDocument(input);
+        // Should keep long macro names intact
+        assert.ok(result.includes('MX8MP_IOMUXC_HDMI_DDC_SCL__HDMIMIX_HDMI_SCL'), 'Long macro should remain intact');
+        assert.ok(result.includes('MX8MP_IOMUXC_HDMI_DDC_SDA__HDMIMIX_HDMI_SDA'), 'Long macro should remain intact');
+        // Make sure it's not split character by character
+        assert.ok(!result.match(/M\s+X\s+8\s+M\s+P_/), 'Should not split macro into characters');
+    });
+});
+
+suite('DTS Formatter - fsl,pins Alignment', () => {
+    test('Should align hex values when first entry has trailing inline comment', async () => {
+        // The inline comment after the hex value must not break column alignment for remaining entries
+        const input = `&iomuxc {
+\tpinctrl_pcie0: pcie0grp {
+\t\tfsl,pins = <MX8MP_IOMUXC_I2C4_SCL__PCIE_CLKREQ_B\t0x60 /* open drain, pull up */
+\t\t\t    MX8MP_IOMUXC_SD1_DATA5__GPIO2_IO07\t0x40
+\t\t>;
+\t};
+};`;
+        const result = await formatDocument(input);
+        const lines = result.split('\n');
+        const pinLines = lines.filter(l => l.includes('MX8MP_IOMUXC_'));
+        assert.strictEqual(pinLines.length, 2, 'Should have two pin lines');
+        // Both hex values should be at the same VISUAL column (expand tabs before comparing)
+        const col0 = expandTabs(pinLines[0]).indexOf('0x');
+        const col1 = expandTabs(pinLines[1]).indexOf('0x');
+        assert.strictEqual(col0, col1, `Hex values should align: col0=${col0} col1=${col1}`);
+        // Inline comment should be preserved
+        assert.ok(result.includes('/* open drain, pull up */'), 'Inline comment should be preserved');
+    });
+
+    test('Should preserve embedded block comment and keep alignment', async () => {
+        // A block comment between pin entries must be passed through unchanged
+        // and must not corrupt the column alignment of surrounding entries
+        const input = `&iomuxc {
+\tpinctrl_hog: hoggrp {
+\t\tfsl,pins = <MX8MP_IOMUXC_HDMI_DDC_SCL__HDMIMIX_HDMI_SCL\t0x400001c2
+\t\t\t    MX8MP_IOMUXC_HDMI_HPD__HDMIMIX_HDMI_HPD\t\t0x40000010
+\t\t\t    /*
+\t\t\t     * M.2 reference clock selection
+\t\t\t     */
+\t\t\t    MX8MP_IOMUXC_SD1_DATA7__GPIO2_IO09\t\t0x1c4
+\t\t>;
+\t};
+};`;
+        const result = await formatDocument(input);
+        // Block comment should be preserved
+        assert.ok(result.includes('M.2 reference clock selection'), 'Block comment should be preserved');
+        const lines = result.split('\n');
+        const pinLines = lines.filter(l => l.includes('MX8MP_IOMUXC_'));
+        assert.strictEqual(pinLines.length, 3, 'Should have three pin lines');
+        // All hex values should be at the same VISUAL column (expand tabs before comparing)
+        const cols = pinLines.map(l => expandTabs(l).indexOf('0x'));
+        assert.ok(cols.every(c => c === cols[0]), `All hex values should align: ${cols}`);
+    });
+
+    test('Should align hex values with variable-length keys', async () => {
+        // Shorter keys need extra tabs to align with the longest key in the group
+        const input = `&iomuxc {
+\tpinctrl_flexspi0: flexspi0grp {
+\t\tfsl,pins = <MX8MP_IOMUXC_NAND_ALE__FLEXSPI_A_SCLK\t0x1c2
+\t\t\t    MX8MP_IOMUXC_NAND_DATA03__FLEXSPI_A_DATA03\t0x82
+\t\t>;
+\t};
+};`;
+        const result = await formatDocument(input);
+        const lines = result.split('\n');
+        const pinLines = lines.filter(l => l.includes('MX8MP_IOMUXC_NAND_'));
+        assert.strictEqual(pinLines.length, 2, 'Should have two pin lines');
+        // Both hex values should be at the same VISUAL column (expand tabs before comparing)
+        const col0 = expandTabs(pinLines[0]).indexOf('0x');
+        const col1 = expandTabs(pinLines[1]).indexOf('0x');
+        assert.strictEqual(col0, col1, `Hex values should align: col0=${col0} col1=${col1}`);
+    });
+
+    test('Should keep source-pdos with internal commas on single line', async () => {
+        // Commas inside PDO_FIXED(...) are NOT value separators — the whole thing stays on one line
+        const input = `/ {
+\tusb_con: connector {
+\t\tsource-pdos = <PDO_FIXED(5000, 3000, PDO_FIXED_USB_COMM)>;
+\t};
+};`;
+        const result = await formatDocument(input);
+        const lines = result.split('\n');
+        const pdoLine = lines.find(l => l.includes('source-pdos'));
+        assert.ok(pdoLine, 'source-pdos property should be present');
+        assert.ok(
+            pdoLine.includes('PDO_FIXED(5000, 3000, PDO_FIXED_USB_COMM)'),
+            'PDO_FIXED call must remain intact on one line'
+        );
+    });
+
+    test('Should keep each PDO entry on its own line for sink-pdos', async () => {
+        // When PDO entries are on separate lines they should each stay on their own line,
+        // aligned to the opening '<'
+        const input = `/ {
+\tusb_con: connector {
+\t\tsink-pdos = <PDO_FIXED(5000, 3000, PDO_FIXED_USB_COMM)
+\t\t\t     PDO_VAR(5000, 20000, 3000)
+\t\t>;
+\t};
+};`;
+        const result = await formatDocument(input);
+        assert.ok(result.includes('PDO_FIXED(5000, 3000, PDO_FIXED_USB_COMM)'), 'PDO_FIXED entry should be intact');
+        assert.ok(result.includes('PDO_VAR(5000, 20000, 3000)'), 'PDO_VAR entry should be intact');
+        // They must be on separate lines
+        const lines = result.split('\n');
+        const fixedLine = lines.findIndex(l => l.includes('PDO_FIXED'));
+        const varLine = lines.findIndex(l => l.includes('PDO_VAR'));
+        assert.ok(fixedLine >= 0 && varLine >= 0, 'Both PDO entries should appear');
+        assert.notStrictEqual(fixedLine, varLine, 'PDO_FIXED and PDO_VAR must be on separate lines');
+        // PDO_VAR line should be indented to align with the opening '<'
+        const pdoVarLine = lines[varLine];
+        assert.ok(pdoVarLine.startsWith('\t'), 'PDO_VAR line should be indented');
+    });
+});
+
+suite('DTS Formatter - fsl,pins Alignment (spaces mode)', () => {
+    const spacesOpts: vscode.FormattingOptions = { tabSize: 8, insertSpaces: true };
+
+    test('Should align hex values using spaces only (no tabs in output)', async () => {
+        const input = `&iomuxc {
+\tpinctrl_ecspi2: ecspi2grp {
+\t\tfsl,pins = <MX8MP_IOMUXC_ECSPI2_SCLK__ECSPI2_SCLK\t0x82
+\t\t\t    MX8MP_IOMUXC_ECSPI2_MOSI__ECSPI2_MOSI\t0x82
+\t\t\t    MX8MP_IOMUXC_ECSPI2_MISO__ECSPI2_MISO\t0x82
+\t\t>;
+\t};
+};`;
+        const result = await formatDocument(input, spacesOpts);
+        const lines = result.split('\n');
+        const pinLines = lines.filter(l => l.includes('MX8MP_IOMUXC_ECSPI2_'));
+        assert.strictEqual(pinLines.length, 3, 'Should have three pin lines');
+        // No tabs should appear in the output
+        assert.ok(!result.includes('\t'), 'Output must not contain tabs in spaces mode');
+        // All hex values at the same column
+        const cols = pinLines.map(l => l.indexOf('0x'));
+        assert.ok(cols.every(c => c === cols[0]), `Hex values should align: ${cols}`);
+    });
+
+    test('Should use exactly 1 space after longest key (no 8-space jumps)', async () => {
+        // In spaces mode the separator after the longest key must be exactly 1 space,
+        // not rounded up to the next 8-char boundary.
+        const input = `&iomuxc {
+\tpinctrl_ecspi2: ecspi2grp {
+\t\tfsl,pins = <MX8MP_IOMUXC_ECSPI2_SCLK__ECSPI2_SCLK\t0x82
+\t\t\t    MX8MP_IOMUXC_ECSPI2_MOSI__ECSPI2_MOSI\t0x82
+\t\t>;
+\t};
+};`;
+        const result = await formatDocument(input, spacesOpts);
+        const lines = result.split('\n');
+        const pinLines = lines.filter(l => l.includes('MX8MP_IOMUXC_ECSPI2_'));
+        // Find the longest key line and verify it has exactly one space before its hex value
+        const longestKeyLine = pinLines.reduce((a, b) =>
+            a.indexOf('0x') > b.indexOf('0x') ? a : b
+        );
+        // The character immediately before '0x' should be a single space
+        const hexIdx = longestKeyLine.indexOf('0x');
+        assert.strictEqual(
+            longestKeyLine[hexIdx - 1], ' ',
+            'There should be exactly one space before the hex value on the longest-key line'
+        );
+        assert.notStrictEqual(
+            longestKeyLine[hexIdx - 2], ' ',
+            'There should not be two spaces before the hex value on the longest-key line'
+        );
+    });
+
+    test('Should align hex values with variable-length keys using spaces', async () => {
+        const input = `&iomuxc {
+\tpinctrl_flexspi0: flexspi0grp {
+\t\tfsl,pins = <MX8MP_IOMUXC_NAND_ALE__FLEXSPI_A_SCLK\t0x1c2
+\t\t\t    MX8MP_IOMUXC_NAND_DATA03__FLEXSPI_A_DATA03\t0x82
+\t\t>;
+\t};
+};`;
+        const result = await formatDocument(input, spacesOpts);
+        assert.ok(!result.includes('\t'), 'Output must not contain tabs in spaces mode');
+        const lines = result.split('\n');
+        const pinLines = lines.filter(l => l.includes('MX8MP_IOMUXC_NAND_'));
+        assert.strictEqual(pinLines.length, 2, 'Should have two pin lines');
+        // Hex values at the same column (no tab expansion needed since there are no tabs)
+        const col0 = pinLines[0].indexOf('0x');
+        const col1 = pinLines[1].indexOf('0x');
+        assert.strictEqual(col0, col1, `Hex values should align: col0=${col0} col1=${col1}`);
+    });
+
+    test('Should convert tabs in single-entry pin value to spaces', async () => {
+        // A single-pin property like pwm1 may have a raw tab between key and hex.
+        // In spaces mode that tab must be replaced with spaces.
+        const input = `&iomuxc {
+\tpinctrl_pwm1: pwm1grp {
+\t\tfsl,pins = <MX8MP_IOMUXC_GPIO1_IO01__PWM1_OUT\t0x116>;
+\t};
+};`;
+        const result = await formatDocument(input, spacesOpts);
+        assert.ok(!result.includes('\t'), 'Output must not contain tabs in spaces mode');
+        assert.ok(result.includes('MX8MP_IOMUXC_GPIO1_IO01__PWM1_OUT'), 'Pin macro should be intact');
+        assert.ok(result.includes('0x116'), 'Hex value should be present');
     });
 });


### PR DESCRIPTION
Fix multiple formatting issues:
- do not normalize labels inside quoted strings
  - labels like `label = "yellow:status";` have been split
- fix handling list of properties
  -  try to do the same formatting style for separated properties
    - ```dts
      fsl,pins = <MX8MP_IOMUXC_SPDIF_RX__GPIO5_IO04	0x6>,
                 <MX8MP_IOMUXC_NAND_CE0_B__GPIO3_IO01	0x6>;
      ```
    - ```dts
      fsl,pins = <MX8MP_IOMUXC_SPDIF_RX__GPIO5_IO04	0x6,
                  MX8MP_IOMUXC_NAND_CE0_B__GPIO3_IO01	0x6>;
      ```
- unify comment style in tests